### PR TITLE
Enforce REQUIREMENT-TEMPLATE.md usage in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,20 @@ Full-stack geospatial platform for ingesting, validating, processing, analyzing,
 2. Use Docker Compose for local services (PostGIS, Redis)
 3. Frontend and backend live in separate directories within the monorepo
 
+## Issue Creation
+
+When creating new GitHub issues, **always** use the structure defined in [REQUIREMENT-TEMPLATE.md](REQUIREMENT-TEMPLATE.md). Every issue must include:
+
+- Summary and motivation with spec references
+- Numbered, testable requirements (no subjective language)
+- Data model and API changes (or "None")
+- Security considerations (mandatory for untrusted input)
+- Step-by-step development plan with file paths
+- Test plan mapping each requirement to a test with tier
+- Concrete acceptance criteria checklist
+
+Do not create issues that skip sections or use vague requirements. If a requirement cannot be traced to INITIAL-PLAN.md, ARCHITECTURE.md, or CODING-CONVENTIONS.md, update the spec first.
+
 ## Branching Strategy
 - `main` is the stable branch — always deployable
 - Create feature branches from `main`: `issue-<number>-<short-description>`


### PR DESCRIPTION
## Summary

- Adds an **Issue Creation** section to `CLAUDE.md` that instructs Claude to always follow `REQUIREMENT-TEMPLATE.md` when opening new GitHub issues
- Ensures every issue automatically gets testable requirements, spec traceability, security considerations, and test plans

Closes #51

## Test plan

- [ ] Open a new issue via Claude and verify it follows the template structure
- [ ] Confirm CLAUDE.md renders correctly with the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)