### PR TITLE
Add 'new issue' shorthand command to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,10 @@ Full-stack geospatial platform for ingesting, validating, processing, analyzing,
 2. Use Docker Compose for local services (PostGIS, Redis)
 3. Frontend and backend live in separate directories within the monorepo
 
+## Shorthand Commands
+
+- **"new issue: <description>"** — Create a new GitHub issue only. Do **not** create a branch, submit a PR, or merge anything. Just file the issue using the template below and return the issue URL.
+
 ## Issue Creation
 
 When creating new GitHub issues, **always** use the structure defined in [REQUIREMENT-TEMPLATE.md](REQUIREMENT-TEMPLATE.md). Every issue must include:


### PR DESCRIPTION
## Summary
- Adds a "Shorthand Commands" section to CLAUDE.md
- Defines `"new issue: <description>"` as a command to create a GitHub issue only (no branch/PR/merge)

Closes #57

## Test plan
- [ ] Verify CLAUDE.md contains the new "Shorthand Commands" section
- [ ] Verify the shorthand explicitly prohibits branch/PR/merge creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)